### PR TITLE
Fix dash in unattend template

### DIFF
--- a/templates/unattend.xml.j2
+++ b/templates/unattend.xml.j2
@@ -75,13 +75,13 @@
                 </SynchronousCommand>
 {% else %}
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c powershell –Command "{{ expand_disk }}"</CommandLine>
+                    <CommandLine>cmd.exe /c powershell -Command "{{ expand_disk }}"</CommandLine>
                     <Description>Resize partition</Description>
                     <Order>1</Order>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c powershell –Command "{{ set_network_to_private }}"</CommandLine>
+                    <CommandLine>cmd.exe /c powershell -Command "{{ set_network_to_private }}"</CommandLine>
                     <Description>Set network connection profile to private</Description>
                     <Order>2</Order>
                     <RequiresUserInput>true</RequiresUserInput>


### PR DESCRIPTION
## Summary
- fix incorrect dash in the unattend.xml template

## Testing
- `ansible-playbook tests/test.yml -i tests/inventory --syntax-check`
- `ansible-lint`


------
https://chatgpt.com/codex/tasks/task_e_684512ce5ea8832da1d488f4b9b0674c